### PR TITLE
Uppdaterade info om Ingarö Rosteri

### DIFF
--- a/_data/roasters.yml
+++ b/_data/roasters.yml
@@ -248,10 +248,11 @@
   subscription: false
 - name: Ingarö Rosteri
   cafe: false
-  comment: Etablerat 2015 i Stockholms skärgård.
+  comment: Ekologiskt specialkaffe. Etablerat 2015 i Stockholms skärgård.
   courses: false
   location: Ingarö
-  subscription: false
+  singleorigin: true
+  subscription: true
   url: ingarorosteri.se
   webshop: true
 - name: Johan & Nyström


### PR DESCRIPTION
Ingarö Rosteri har (numera?) en lite speciell inriktning på enbart ekologiskt specialkaffe och därav utökades beskrivningen. Vissa av dessa är single origin så även den flaggan lades till.